### PR TITLE
Refactoring, improved options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -281,6 +281,7 @@ grunt test:code-style
 ## Changelog
 
 * TBD:
+  * `test()` method to allow for custom tests.
   * Deprecated `lookupCountry()`, `loadCountryData()`, and `loadCountryDataSync()`. These will be removed in a future release. Use [geoip-native-lite](https://github.com/chill117/geoip-native-lite) if you need to check the geo-location for your proxies.
 * v0.3.0:
   * Performance improvements for `testAll()`.

--- a/test/unit/all.js
+++ b/test/unit/all.js
@@ -11,22 +11,15 @@ describe('testAll(proxy[, options], cb)', function() {
 	var appServer;
 
 	before(function() {
-
 		appServer = helpers.createAppServer(3001, '127.0.0.1');
-
-		ProxyVerifier._protocolTestUrl = 'http://127.0.0.1:3001/check';
-		ProxyVerifier._anonymityTestUrl = 'http://127.0.0.1:3001/check';
-		ProxyVerifier._tunnelTestUrl = 'https://127.0.0.1:3002/check';
 	});
 
 	after(function() {
-
 		appServer.http.close();
 		appServer.https.close();
 	});
 
 	it('should be a function', function() {
-
 		expect(ProxyVerifier.testAll).to.be.a('function');
 	});
 
@@ -36,12 +29,10 @@ describe('testAll(proxy[, options], cb)', function() {
 		var proxyServer;
 
 		before(function() {
-
 			proxyServer = helpers.createProxyServer(5050, '127.0.0.2');
 		});
 
 		after(function() {
-
 			proxyServer.close();
 			proxyServer.http.close();
 			proxyServer.https.close();
@@ -57,15 +48,19 @@ describe('testAll(proxy[, options], cb)', function() {
 					protocols: [proxyProtocol]
 				};
 
-				var requestOptions = {
-					strictSSL: false,
-					proxyOptions: {
-						rejectUnauthorized: false
-					},
-					timeout: 100
+				var options = {
+					testUrl: 'https://127.0.0.1:3002/check',
+					ipAddressCheckUrl: 'http://127.0.0.1:3001/check',
+					requestOptions: {
+						strictSSL: false,
+						agentOptions: {
+							rejectUnauthorized: false
+						},
+						timeout: 100
+					}
 				};
 
-				ProxyVerifier.testAll(proxy, requestOptions, function(error, result) {
+				ProxyVerifier.testAll(proxy, options, function(error, result) {
 
 					try {
 						expect(error).to.equal(null);

--- a/test/unit/anonymityLevel.js
+++ b/test/unit/anonymityLevel.js
@@ -12,18 +12,15 @@ describe('testAnonymityLevel(proxy[, options], cb)', function() {
 	var appServer;
 
 	before(function() {
-
 		appServer = helpers.createAppServer(3001, '127.0.0.1');
 	});
 
 	after(function() {
-
 		appServer.http.close();
 		appServer.https.close();
 	});
 
 	it('should be a function', function() {
-
 		expect(ProxyVerifier.testAnonymityLevel).to.be.a('function');
 	});
 
@@ -61,9 +58,7 @@ describe('testAnonymityLevel(proxy[, options], cb)', function() {
 		});
 
 		after(function() {
-
 			_.each(Array.prototype.concat.apply([], _.values(proxyServers)), function(proxyServer) {
-
 				proxyServer.close();
 				proxyServer.http.close();
 				proxyServer.https.close();
@@ -71,8 +66,6 @@ describe('testAnonymityLevel(proxy[, options], cb)', function() {
 		});
 
 		it('should return NULL when test URL is inaccessible', function(done) {
-
-			ProxyVerifier._anonymityTestUrl = 'http://127.0.0.1:3001/does-not-exist';
 
 			var proxyServer = proxyServers.elite[0];
 
@@ -82,15 +75,18 @@ describe('testAnonymityLevel(proxy[, options], cb)', function() {
 				protocols: ['http']
 			};
 
-			var requestOptions = {
-				strictSSL: false,
-				proxyOptions: {
-					rejectUnauthorized: false
-				},
-				timeout: 100
+			var options = {
+				testUrl: 'http://127.0.0.1:3001/does-not-exist',
+				requestOptions: {
+					strictSSL: false,
+					agentOptions: {
+						rejectUnauthorized: false
+					},
+					timeout: 100
+				}
 			};
 
-			ProxyVerifier.testAnonymityLevel(proxy, requestOptions, function(error, result) {
+			ProxyVerifier.testAnonymityLevel(proxy, options, function(error, result) {
 
 				try {
 					expect(error).to.not.equal(null);
@@ -108,8 +104,6 @@ describe('testAnonymityLevel(proxy[, options], cb)', function() {
 
 			it(anonymityLevel, function(done) {
 
-				ProxyVerifier._anonymityTestUrl = 'http://127.0.0.1:3001/check';
-
 				async.times(proxyServers[anonymityLevel].length, function(index, next) {
 
 					var proxyServer = proxyServers[anonymityLevel][index];
@@ -120,15 +114,19 @@ describe('testAnonymityLevel(proxy[, options], cb)', function() {
 						protocols: ['http']
 					};
 
-					var requestOptions = {
-						strictSSL: false,
-						proxyOptions: {
-							rejectUnauthorized: false
-						},
-						timeout: 100
+					var options = {
+						testUrl: 'http://127.0.0.1:3001/check',
+						ipAddressCheckUrl: 'http://127.0.0.1:3001/check',
+						requestOptions: {
+							strictSSL: false,
+							agentOptions: {
+								rejectUnauthorized: false
+							},
+							timeout: 100
+						}
 					};
 
-					ProxyVerifier.testAnonymityLevel(proxy, requestOptions, function(error, result) {
+					ProxyVerifier.testAnonymityLevel(proxy, options, function(error, result) {
 
 						try {
 							expect(error).to.equal(null);

--- a/test/unit/normalizeProxy.js
+++ b/test/unit/normalizeProxy.js
@@ -8,7 +8,6 @@ var ProxyVerifier = require('../../');
 describe('normalizeProxy(proxy)', function() {
 
 	it('should be a function', function() {
-
 		expect(ProxyVerifier.normalizeProxy).to.be.a('function');
 	});
 

--- a/test/unit/protocol.js
+++ b/test/unit/protocol.js
@@ -11,34 +11,27 @@ describe('testProtocol(proxy[, options], cb)', function() {
 	var appServer;
 
 	before(function() {
-
 		appServer = helpers.createAppServer(3001, '127.0.0.1');
-
-		ProxyVerifier._protocolTestUrl = 'http://127.0.0.1:3001/check';
 	});
 
 	var proxyServer;
 
 	before(function() {
-
 		proxyServer = helpers.createProxyServer(5050, '127.0.0.2');
 	});
 
 	after(function() {
-
 		appServer.http.close();
 		appServer.https.close();
 	});
 
 	after(function() {
-
 		proxyServer.close();
 		proxyServer.http.close();
 		proxyServer.https.close();
 	});
 
 	it('should be a function', function() {
-
 		expect(ProxyVerifier.testProtocol).to.be.a('function');
 	});
 
@@ -56,15 +49,18 @@ describe('testProtocol(proxy[, options], cb)', function() {
 					protocols: [proxyProtocol]
 				};
 
-				var requestOptions = {
-					strictSSL: false,
-					proxyOptions: {
-						rejectUnauthorized: false
-					},
-					timeout: 100
+				var options = {
+					testUrl: 'http://127.0.0.1:3001/check',
+					requestOptions: {
+						strictSSL: false,
+						agentOptions: {
+							rejectUnauthorized: false
+						},
+						timeout: 100
+					}
 				};
 
-				ProxyVerifier.testProtocol(proxy, requestOptions, function(error, result) {
+				ProxyVerifier.testProtocol(proxy, options, function(error, result) {
 
 					try {
 						expect(error).to.equal(null);
@@ -97,15 +93,18 @@ describe('testProtocol(proxy[, options], cb)', function() {
 					protocols: [wrongProtocol]
 				};
 
-				var requestOptions = {
-					strictSSL: false,
-					proxyOptions: {
-						rejectUnauthorized: false
-					},
-					timeout: 100
+				var options = {
+					testUrl: 'http://127.0.0.1:3001/check',
+					requestOptions: {
+						strictSSL: false,
+						agentOptions: {
+							rejectUnauthorized: false
+						},
+						timeout: 100
+					}
 				};
 
-				ProxyVerifier.testProtocol(proxy, requestOptions, function(error, result) {
+				ProxyVerifier.testProtocol(proxy, options, function(error, result) {
 
 					try {
 						expect(error).to.equal(null);
@@ -155,16 +154,19 @@ describe('testProtocol(proxy[, options], cb)', function() {
 				protocols: [proxyProtocol]
 			};
 
-			var requestOptions = {
-				strictSSL: false,
-				proxyOptions: {
-					rejectUnauthorized: false
-				},
-				timeout: 100,
-				auth: auth
+			var options = {
+				testUrl: 'http://127.0.0.1:3001/check',
+				requestOptions: {
+					strictSSL: false,
+					agentOptions: {
+						rejectUnauthorized: false
+					},
+					timeout: 100,
+					auth: auth
+				}
 			};
 
-			ProxyVerifier.testProtocol(proxy, requestOptions, function(error, result) {
+			ProxyVerifier.testProtocol(proxy, options, function(error, result) {
 
 				try {
 					expect(error).to.equal(null);
@@ -189,19 +191,22 @@ describe('testProtocol(proxy[, options], cb)', function() {
 				protocols: [proxyProtocol]
 			};
 
-			var requestOptions = {
-				strictSSL: false,
-				proxyOptions: {
-					rejectUnauthorized: false
-				},
-				timeout: 100,
-				auth: {
-					user: 'test',
-					pass: 'incorrect-password'
+			var options = {
+				testUrl: 'http://127.0.0.1:3001/check',
+				requestOptions: {
+					strictSSL: false,
+					agentOptions: {
+						rejectUnauthorized: false
+					},
+					timeout: 100,
+					auth: {
+						user: 'test',
+						pass: 'incorrect-password'
+					}
 				}
 			};
 
-			ProxyVerifier.testProtocol(proxy, requestOptions, function(error, result) {
+			ProxyVerifier.testProtocol(proxy, options, function(error, result) {
 
 				try {
 					expect(error).to.equal(null);

--- a/test/unit/request.js
+++ b/test/unit/request.js
@@ -98,7 +98,7 @@ describe('request(method, url[, options], cb)', function() {
 							var requestOptions = {
 								strictSSL: false,
 								proxy: proxy,
-								proxyOptions: {
+								agentOptions: {
 									rejectUnauthorized: false
 								},
 								timeout: 100

--- a/test/unit/tunnel.js
+++ b/test/unit/tunnel.js
@@ -11,15 +11,10 @@ describe('testTunnel(proxy[, options], cb)', function() {
 	var appServer;
 
 	before(function() {
-
 		appServer = helpers.createAppServer(3001, '127.0.0.1');
-
-		// The HTTPS app server listens on port 3002.
-		ProxyVerifier._tunnelTestUrl = 'https://127.0.0.1:3002/check';
 	});
 
 	after(function() {
-
 		appServer.http.close();
 		appServer.https.close();
 	});
@@ -27,13 +22,11 @@ describe('testTunnel(proxy[, options], cb)', function() {
 	var proxyServers = {};
 
 	before(function() {
-
 		proxyServers.withTunneling = helpers.createProxyServer(5050, '127.0.0.2');
 		proxyServers.withoutTunneling = helpers.createProxyServer(5051, '127.0.0.3', { tunnel: false });
 	});
 
 	after(function() {
-
 		_.each(_.values(proxyServers), function(proxyServer) {
 			proxyServer.close();
 			proxyServer.http.close();
@@ -42,7 +35,6 @@ describe('testTunnel(proxy[, options], cb)', function() {
 	});
 
 	it('should be a function', function() {
-
 		expect(ProxyVerifier.testTunnel).to.be.a('function');
 	});
 
@@ -57,15 +49,19 @@ describe('testTunnel(proxy[, options], cb)', function() {
 			protocols: [proxyProtocol]
 		};
 
-		var requestOptions = {
-			strictSSL: false,
-			proxyOptions: {
-				rejectUnauthorized: false
-			},
-			timeout: 100
+		var options = {
+			// The HTTPS app server listens on port 3002.
+			testUrl: 'https://127.0.0.1:3002/check',
+			requestOptions: {
+				strictSSL: false,
+				agentOptions: {
+					rejectUnauthorized: false
+				},
+				timeout: 100
+			}
 		};
 
-		ProxyVerifier.testTunnel(proxy, requestOptions, function(error, result) {
+		ProxyVerifier.testTunnel(proxy, options, function(error, result) {
 
 			try {
 				expect(error).to.equal(null);
@@ -89,15 +85,19 @@ describe('testTunnel(proxy[, options], cb)', function() {
 			protocols: [proxyProtocol]
 		};
 
-		var requestOptions = {
-			strictSSL: false,
-			proxyOptions: {
-				rejectUnauthorized: false
-			},
-			timeout: 100
+		var options = {
+			// The HTTPS app server listens on port 3002.
+			testUrl: 'https://127.0.0.1:3002/check',
+			requestOptions: {
+				strictSSL: false,
+				agentOptions: {
+					rejectUnauthorized: false
+				},
+				timeout: 100
+			}
 		};
 
-		ProxyVerifier.testTunnel(proxy, requestOptions, function(error, result) {
+		ProxyVerifier.testTunnel(proxy, options, function(error, result) {
 
 			try {
 				expect(error).to.equal(null);


### PR DESCRIPTION
Can now run your own custom tests like this:
```js
ProxyVerifier.test(proxy, {
    testUrl: 'https://www.google.com',
    testFn: function(data, status, headers) {

        // Check the response data, status, and headers.

        // Throw an error if the test failed.
        throw new Error('Test failed!');

        // Do nothing if the test passed.
    }
}, function(error, results) {
    // Do something with error or results.
});
```