### PR TITLE
Add support for a custom request timeout option

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ var ProxyVerifier = module.exports = {
 			}
 
 			try {
-				var ipAddress = options.ipAddressCheckFn(data, status, headers);	
+				var ipAddress = options.ipAddressCheckFn(data, status, headers);
 			} catch (error) {
 				return cb(error);
 			}
@@ -417,6 +417,7 @@ var ProxyVerifier = module.exports = {
 		});
 
 		req.on('error', done);
+		req.on('timeout', req.abort);
 		req.end();
 
 		return req;


### PR DESCRIPTION
The option timeout for request fires an event that must be listen and processed. When validating proxies, you expect to get an error in those proxies that fire a timeout. More information about hoy timeout option works can be found here: https://github.com/nodejs/node/issues/12005

I just added a minimum amount of code to support this behaviour. I test it and it works fine.