### PR TITLE
Added section about passing options to request

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,6 +271,34 @@ ProxyVerifier.test(proxy, {
 });
 ```
 
+## Passing options to request
+In case you want to pass options to the [request](https://github.com/request/request) call itself, pass them through **requestOptions** key within the  options parameter:
+
+Usage:
+```js
+var ProxyVerifier = require('proxy-verifier');
+
+var proxy = {
+	ipAddress: '127.0.0.1',
+	port: 8080,
+	protocol: 'http'
+};
+
+var options = {
+	requestOptions: {
+		timeout: 3000
+	}
+};
+
+ProxyVerifier.testAnonymityLevel(proxy, options, function(error, anonymityLevel) {
+
+	if (error) {
+		// Some unusual error occurred.
+	} else {
+		// anonymityLevel will be a string equal to "transparent", "anonymous", or "elite".
+	}
+});
+```
 
 ## Contributing
 


### PR DESCRIPTION
When you want to pass options to the request call, it is not enough to set them in the options argument, they need to be within the key **requestOptions**.

Also I think, that the user passed options should be the last ones applied and override anything that is set by the library. Right now the library is overwriting some of the options.

I would suggest setting the user options for requests before the actual call to request:

https://github.com/chill117/proxy-verifier/blob/ff1d21e9d3c429de2ead426848b061ed1a82579f/index.js#L388

I am aware this can break the call - but if the user is passing options to request, I guess he knows what he is doing.

If you like the idea I can submit a PR.